### PR TITLE
Handle redirects (allows the upload of bukkit plugins).

### DIFF
--- a/src/main/java/net/cazzar/gradle/curseforge/CurseUpload.java
+++ b/src/main/java/net/cazzar/gradle/curseforge/CurseUpload.java
@@ -117,6 +117,17 @@ public class CurseUpload extends DefaultTask {
             HttpResponse response = client.execute(post);
             HttpEntity ent = response.getEntity();
 
+            if (response.getStatusLine().getStatusCode() == 301) {
+                post = new HttpPost(response.getLastHeader("Location").getValue());
+                post.addHeader("X-API-Key", api_key);
+                post.setEntity(entity);
+
+                EntityUtils.consume(ent);
+
+                response = client.execute(post);
+                ent = response.getEntity();
+            }
+
             if (response.getStatusLine().getStatusCode() != 201) {
                 Gson gson = new Gson();
                 @SuppressWarnings("unchecked") Map<String, List<String>> data = gson.fromJson(EntityUtils.toString(ent), Map.class);


### PR DESCRIPTION
It's a rather dirty workaround, but it does the job.

Tried to use `LaxRedirectStrategy`, but something goes wrong somewhere (POST is most likely changed to GET while the redirect is performed).
